### PR TITLE
feat(tautulli): implement tautulli now command

### DIFF
--- a/bin/arrctl
+++ b/bin/arrctl
@@ -29,7 +29,7 @@ Commands:
     sonarr      Manage Sonarr (TV shows)
     radarr      Manage Radarr (Movies)
     overseerr   Manage Overseerr (Requests)
-    tautulli    Manage Tautulli (Plex stats)
+    tautulli    View Plex activity (who is streaming)
 
 Options:
     -h, --help      Show this help message
@@ -55,6 +55,7 @@ Examples:
     arrctl radarr list --monitored
     arrctl radarr search "The Matrix"
     arrctl radarr add --id 603 --search
+    arrctl tautulli now
 
 EOF
 }

--- a/lib/tautulli.sh
+++ b/lib/tautulli.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# tautulli.sh - Tautulli (Plex stats) CLI module
+# POSIX compliant - tested with dash
+
+# Main entry point for tautulli subcommand
+tautulli_main() {
+    # Handle no arguments or help before loading config
+    if [ $# -eq 0 ]; then
+        tautulli_help
+        return 0
+    fi
+    
+    case "$1" in
+        -h|--help|help)
+            tautulli_help
+            return 0
+            ;;
+    esac
+    
+    # Now load config and parse args for actual commands
+    load_config "tautulli"
+    parse_service_args "$@"
+    eval "set -- $_REMAINING_ARGS"
+    
+    case "${1:-}" in
+        now)
+            shift
+            tautulli_now "$@"
+            ;;
+        *)
+            die "Unknown tautulli command: $1. Use 'arrctl tautulli help' for usage."
+            ;;
+    esac
+}
+
+# Show help for tautulli commands
+tautulli_help() {
+    cat <<EOF
+arrctl tautulli - View Plex activity via Tautulli
+
+Usage: arrctl tautulli <command> [options]
+
+Commands:
+    now              Show who is currently streaming
+    help             Show this help message
+
+Options:
+    --format FORMAT  Output format: json|table|auto (default: auto)
+    -q, --quiet      Exit code only (0=active, 1=none)
+
+Exit Codes:
+    0                Active streams found (or help displayed)
+    1                No active streams
+
+Examples:
+    arrctl tautulli now
+    arrctl tautulli now --format=json
+    arrctl tautulli now --quiet && echo "Someone is watching" || echo "No active streams"
+EOF
+}
+
+# Show current streaming activity
+# Usage: tautulli_now
+tautulli_now() {
+    check_deps curl jq
+    
+    # Tautulli uses query-param auth (NOT X-Api-Key header like *arr services)
+    _url="${SERVICE_URL%/}/api/v2?cmd=get_activity&apikey=${SERVICE_API_KEY}"
+    _response="$(curl -s "$_url")"
+    
+    # Check for API errors
+    _result="$(printf '%s' "$_response" | jq -r '.response.result // "error"')"
+    if [ "$_result" != "success" ]; then
+        _message="$(printf '%s' "$_response" | jq -r '.response.message // "Unknown error"')"
+        die "Tautulli API error: $_message"
+    fi
+    
+    # Extract sessions from .response.data.sessions (wrapped response)
+    _sessions="$(printf '%s' "$_response" | jq '.response.data.sessions // []')"
+    _count="$(printf '%s' "$_sessions" | jq 'length')"
+    
+    # Handle no active streams
+    if [ "$_count" -eq 0 ]; then
+        if [ "$QUIET_MODE" -eq 0 ]; then
+            info "No active streams"
+        fi
+        return 1
+    fi
+    
+    # Quiet mode - just exit with success
+    if [ "$QUIET_MODE" -eq 1 ]; then
+        return 0
+    fi
+    
+    # Format output
+    if [ "$OUTPUT_FORMAT" = "json" ]; then
+        printf '%s\n' "$_sessions" | jq '.'
+    else
+        # Table format with fallback field names
+        printf '%s\n' "$_sessions" | format_table \
+            "User|Title|Progress|Quality|Transcode|State" \
+            '.[] | [
+                (.user // .friendly_name // "Unknown"),
+                (.full_title // .title // "Unknown"),
+                ((.progress_percent // 0 | tostring) + "%"),
+                (.video_full_resolution // .quality_profile // "Unknown"),
+                (.transcode_decision // "Unknown"),
+                (.state // "Unknown")
+            ]'
+    fi
+}

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -76,6 +76,7 @@ if command -v shellcheck >/dev/null 2>&1; then
     test_case "shellcheck: lib/common.sh" shellcheck -s sh "${REPO_DIR}/lib/common.sh"
     test_case "shellcheck: lib/sonarr.sh" shellcheck -s sh "${REPO_DIR}/lib/sonarr.sh"
     test_case "shellcheck: lib/radarr.sh" shellcheck -s sh "${REPO_DIR}/lib/radarr.sh"
+    test_case "shellcheck: lib/tautulli.sh" shellcheck -s sh "${REPO_DIR}/lib/tautulli.sh"
 else
     skip "shellcheck not installed"
 fi
@@ -85,6 +86,7 @@ if command -v dash >/dev/null 2>&1; then
     test_case "dash -n: lib/common.sh" dash -n "${REPO_DIR}/lib/common.sh"
     test_case "dash -n: lib/sonarr.sh" dash -n "${REPO_DIR}/lib/sonarr.sh"
     test_case "dash -n: lib/radarr.sh" dash -n "${REPO_DIR}/lib/radarr.sh"
+    test_case "dash -n: lib/tautulli.sh" dash -n "${REPO_DIR}/lib/tautulli.sh"
 else
     skip "dash not installed"
 fi
@@ -97,12 +99,15 @@ test_case "arrctl sonarr --help works" "$ARRCTL" sonarr --help
 test_case "arrctl sonarr help works" "$ARRCTL" sonarr help
 test_case "arrctl radarr --help works" "$ARRCTL" radarr --help
 test_case "arrctl radarr help works" "$ARRCTL" radarr help
+test_case "arrctl tautulli --help works" "$ARRCTL" tautulli --help
+test_case "arrctl tautulli help works" "$ARRCTL" tautulli help
 
 # Invalid command handling
 printf '\n%s\n' "--- Error Handling ---"
 test_case_fail "arrctl invalid-command fails" "$ARRCTL" invalid-command
 test_case_fail "arrctl sonarr invalid-subcommand fails" "$ARRCTL" sonarr invalid-subcommand
 test_case_fail "arrctl radarr invalid-subcommand fails" "$ARRCTL" radarr invalid-subcommand
+test_case_fail "arrctl tautulli invalid-subcommand fails" "$ARRCTL" tautulli invalid-subcommand
 
 # Help output contains expected content
 printf '\n%s\n' "--- Help Content ---"
@@ -116,6 +121,12 @@ if "$ARRCTL" --help 2>&1 | grep -q "radarr"; then
     pass "Main help mentions radarr"
 else
     fail "Main help mentions radarr"
+fi
+
+if "$ARRCTL" --help 2>&1 | grep -q "tautulli"; then
+    pass "Main help mentions tautulli"
+else
+    fail "Main help mentions tautulli"
 fi
 
 if "$ARRCTL" sonarr --help 2>&1 | grep -q "list"; then
@@ -152,6 +163,12 @@ if "$ARRCTL" radarr --help 2>&1 | grep -q "add"; then
     pass "Radarr help mentions add"
 else
     fail "Radarr help mentions add"
+fi
+
+if "$ARRCTL" tautulli --help 2>&1 | grep -q "now"; then
+    pass "Tautulli help mentions now"
+else
+    fail "Tautulli help mentions now"
 fi
 
 # Summary


### PR DESCRIPTION
## Summary

Implements the `tautulli now` command to show who is currently streaming on Plex.

## Changes

- Add lib/tautulli.sh with the `now` subcommand
- Update bin/arrctl help text with tautulli example
- Add Tautulli tests to test/smoke.sh

## Usage

```sh
arrctl tautulli now                    # Table output
arrctl tautulli now --format=json      # JSON for piping
arrctl tautulli now --quiet && echo "Someone is watching" || echo "No active streams"
```

## Output

Shows: User, Title, Progress %, Quality, Transcode status, State

## Technical Notes

- Uses query-param auth (`?apikey=`) instead of X-Api-Key header (Tautulli API is different from *arr services)
- Parses response from `.response.data.sessions` (wrapped response)
- Returns exit code 1 when no active streams (useful for scripting with --quiet)
- Field names use jq fallbacks for compatibility with different Tautulli versions

## Testing

- All 34 smoke tests pass
- shellcheck clean
- dash -n (POSIX) compliant