### PR TITLE
feat(overseerr): implement request management commands

### DIFF
--- a/bin/arrctl
+++ b/bin/arrctl
@@ -55,6 +55,7 @@ Examples:
     arrctl radarr list --monitored
     arrctl radarr search "The Matrix"
     arrctl radarr add --id 603 --search
+    arrctl overseerr pending
     arrctl tautulli now
 
 EOF

--- a/lib/overseerr.sh
+++ b/lib/overseerr.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+# overseerr.sh - Overseerr (media requests) CLI module
+# POSIX compliant - tested with dash
+
+# Main entry point for overseerr subcommand
+overseerr_main() {
+    # Handle no arguments or help before loading config
+    if [ $# -eq 0 ]; then
+        overseerr_help
+        return 0
+    fi
+    
+    case "$1" in
+        -h|--help|help)
+            overseerr_help
+            return 0
+            ;;
+    esac
+    
+    # Now load config and parse args for actual commands
+    load_config "overseerr"
+    parse_service_args "$@"
+    eval "set -- $_REMAINING_ARGS"
+    
+    case "${1:-}" in
+        pending)
+            shift
+            overseerr_pending "$@"
+            ;;
+        approve)
+            shift
+            overseerr_approve "$@"
+            ;;
+        deny|decline)
+            shift
+            overseerr_deny "$@"
+            ;;
+        *)
+            die "Unknown overseerr command: $1. Use 'arrctl overseerr help' for usage."
+            ;;
+    esac
+}
+
+# Show help for overseerr commands
+overseerr_help() {
+    cat <<EOF
+arrctl overseerr - Manage media requests via Overseerr
+
+Usage: arrctl overseerr <command> [options]
+
+Commands:
+    pending            List pending requests awaiting approval
+    approve <id>       Approve a pending request
+    deny <id>          Deny/decline a pending request
+    help               Show this help message
+
+Options:
+    --format FORMAT    Output format: json|table|auto (default: auto)
+    --message MSG      Message to include when approving (optional)
+    --reason MSG       Reason for denial when declining (optional)
+
+Examples:
+    arrctl overseerr pending
+    arrctl overseerr pending --format=json
+    arrctl overseerr approve 123
+    arrctl overseerr approve 124 --message "Adding tonight"
+    arrctl overseerr deny 125 --reason "Already available"
+    arrctl overseerr decline 126
+EOF
+}
+
+# List pending requests
+# Usage: overseerr_pending
+overseerr_pending() {
+    check_deps curl jq
+    
+    _response="$(api_request GET "/api/v1/request?filter=pending&take=100")"
+    
+    # Extract results array
+    _results="$(printf '%s' "$_response" | jq '.results // []')"
+    _count="$(printf '%s' "$_results" | jq 'length')"
+    
+    # Handle no pending requests
+    if [ "$_count" -eq 0 ]; then
+        info "No pending requests"
+        return 0
+    fi
+    
+    # Format output
+    if [ "$OUTPUT_FORMAT" = "json" ]; then
+        printf '%s\n' "$_results" | jq '.'
+    else
+        # Table format: ID, User, Title, Type, Date
+        printf '%s\n' "$_results" | format_table \
+            "ID|User|Title|Type|Date" \
+            '.[] | [
+                .id,
+                (.requestedBy.username // "Unknown"),
+                (.media.title // "Unknown"),
+                (.media.mediaType // "unknown"),
+                ((.createdAt // "") | split("T")[0])
+            ]'
+    fi
+}
+
+# Approve a pending request
+# Usage: overseerr_approve <id> [--message MSG]
+overseerr_approve() {
+    check_deps curl jq
+    
+    _id=""
+    _message=""
+    
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --message)
+                if [ -z "${2:-}" ]; then
+                    die "--message requires a value"
+                fi
+                _message="$2"
+                shift 2
+                ;;
+            --message=*)
+                _message="${1#--message=}"
+                shift
+                ;;
+            -*)
+                die "Unknown option: $1"
+                ;;
+            *)
+                if [ -z "$_id" ]; then
+                    _id="$1"
+                else
+                    die "Unexpected argument: $1"
+                fi
+                shift
+                ;;
+        esac
+    done
+    
+    # Validate ID
+    if [ -z "$_id" ]; then
+        die "Request ID required. Usage: arrctl overseerr approve <id>"
+    fi
+    
+    # Build request body
+    if [ -n "$_message" ]; then
+        _body="$(printf '{"message":"%s"}' "$_message")"
+    else
+        _body="{}"
+    fi
+    
+    # Make API request (api_request handles errors)
+    api_request POST "/api/v1/request/${_id}/approve" "$_body" >/dev/null
+    
+    info "Approved request $_id"
+}
+
+# Deny/decline a pending request
+# Usage: overseerr_deny <id> [--reason MSG]
+overseerr_deny() {
+    check_deps curl jq
+    
+    _id=""
+    _reason=""
+    
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --reason)
+                if [ -z "${2:-}" ]; then
+                    die "--reason requires a value"
+                fi
+                _reason="$2"
+                shift 2
+                ;;
+            --reason=*)
+                _reason="${1#--reason=}"
+                shift
+                ;;
+            -*)
+                die "Unknown option: $1"
+                ;;
+            *)
+                if [ -z "$_id" ]; then
+                    _id="$1"
+                else
+                    die "Unexpected argument: $1"
+                fi
+                shift
+                ;;
+        esac
+    done
+    
+    # Validate ID
+    if [ -z "$_id" ]; then
+        die "Request ID required. Usage: arrctl overseerr deny <id>"
+    fi
+    
+    # Build request body
+    if [ -n "$_reason" ]; then
+        _body="$(printf '{"reason":"%s"}' "$_reason")"
+    else
+        _body="{}"
+    fi
+    
+    # Make API request (api_request handles errors)
+    api_request POST "/api/v1/request/${_id}/decline" "$_body" >/dev/null
+    
+    info "Declined request $_id"
+}

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -77,6 +77,7 @@ if command -v shellcheck >/dev/null 2>&1; then
     test_case "shellcheck: lib/sonarr.sh" shellcheck -s sh "${REPO_DIR}/lib/sonarr.sh"
     test_case "shellcheck: lib/radarr.sh" shellcheck -s sh "${REPO_DIR}/lib/radarr.sh"
     test_case "shellcheck: lib/tautulli.sh" shellcheck -s sh "${REPO_DIR}/lib/tautulli.sh"
+    test_case "shellcheck: lib/overseerr.sh" shellcheck -s sh "${REPO_DIR}/lib/overseerr.sh"
 else
     skip "shellcheck not installed"
 fi
@@ -87,6 +88,7 @@ if command -v dash >/dev/null 2>&1; then
     test_case "dash -n: lib/sonarr.sh" dash -n "${REPO_DIR}/lib/sonarr.sh"
     test_case "dash -n: lib/radarr.sh" dash -n "${REPO_DIR}/lib/radarr.sh"
     test_case "dash -n: lib/tautulli.sh" dash -n "${REPO_DIR}/lib/tautulli.sh"
+    test_case "dash -n: lib/overseerr.sh" dash -n "${REPO_DIR}/lib/overseerr.sh"
 else
     skip "dash not installed"
 fi
@@ -101,6 +103,8 @@ test_case "arrctl radarr --help works" "$ARRCTL" radarr --help
 test_case "arrctl radarr help works" "$ARRCTL" radarr help
 test_case "arrctl tautulli --help works" "$ARRCTL" tautulli --help
 test_case "arrctl tautulli help works" "$ARRCTL" tautulli help
+test_case "arrctl overseerr --help works" "$ARRCTL" overseerr --help
+test_case "arrctl overseerr help works" "$ARRCTL" overseerr help
 
 # Invalid command handling
 printf '\n%s\n' "--- Error Handling ---"
@@ -108,6 +112,7 @@ test_case_fail "arrctl invalid-command fails" "$ARRCTL" invalid-command
 test_case_fail "arrctl sonarr invalid-subcommand fails" "$ARRCTL" sonarr invalid-subcommand
 test_case_fail "arrctl radarr invalid-subcommand fails" "$ARRCTL" radarr invalid-subcommand
 test_case_fail "arrctl tautulli invalid-subcommand fails" "$ARRCTL" tautulli invalid-subcommand
+test_case_fail "arrctl overseerr invalid-subcommand fails" "$ARRCTL" overseerr invalid-subcommand
 
 # Help output contains expected content
 printf '\n%s\n' "--- Help Content ---"
@@ -127,6 +132,12 @@ if "$ARRCTL" --help 2>&1 | grep -q "tautulli"; then
     pass "Main help mentions tautulli"
 else
     fail "Main help mentions tautulli"
+fi
+
+if "$ARRCTL" --help 2>&1 | grep -q "overseerr"; then
+    pass "Main help mentions overseerr"
+else
+    fail "Main help mentions overseerr"
 fi
 
 if "$ARRCTL" sonarr --help 2>&1 | grep -q "list"; then
@@ -169,6 +180,24 @@ if "$ARRCTL" tautulli --help 2>&1 | grep -q "now"; then
     pass "Tautulli help mentions now"
 else
     fail "Tautulli help mentions now"
+fi
+
+if "$ARRCTL" overseerr --help 2>&1 | grep -q "pending"; then
+    pass "Overseerr help mentions pending"
+else
+    fail "Overseerr help mentions pending"
+fi
+
+if "$ARRCTL" overseerr --help 2>&1 | grep -q "approve"; then
+    pass "Overseerr help mentions approve"
+else
+    fail "Overseerr help mentions approve"
+fi
+
+if "$ARRCTL" overseerr --help 2>&1 | grep -q "deny"; then
+    pass "Overseerr help mentions deny"
+else
+    fail "Overseerr help mentions deny"
 fi
 
 # Summary


### PR DESCRIPTION
## Summary

Implements Overseerr request management for arrctl with three commands:

- `pending` - List pending requests awaiting approval
- `approve <id>` - Approve a pending request
- `deny <id>` - Decline a pending request

## Changes

**New file: lib/overseerr.sh**
- `overseerr_pending`: GET /api/v1/request?filter=pending - displays ID, User, Title, Type, Date in table format
- `overseerr_approve`: POST /api/v1/request/{id}/approve with optional --message flag
- `overseerr_deny`: POST /api/v1/request/{id}/decline with optional --reason flag (also accepts `decline` alias)
- Uses X-Api-Key header authentication via existing api_request() helper
- Supports --format=json for JSON output

**Modified: bin/arrctl**
- Added overseerr example to help text

**Modified: test/smoke.sh**
- Added shellcheck and dash -n tests for overseerr.sh
- Added help command tests for overseerr
- Added help content tests (pending, approve, deny)

## Usage Examples

```sh
arrctl overseerr pending                    # List pending
arrctl overseerr pending --format=json      # JSON output
arrctl overseerr approve 123                # Approve request 123
arrctl overseerr approve 124 --message "Adding tonight"
arrctl overseerr deny 125 --reason "Already available"
arrctl overseerr decline 126                # Same as deny
```

## Testing

- All smoke tests pass (43/43)
- shellcheck clean
- POSIX compliant (dash -n passes)

Closes: Notion ticket 305fd092-1836-81cd-9881-f9aac14402b0