### PR TITLE
feat: add install script and distribution docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# arrctl Makefile
+# Convenience targets for development and installation
+
+.PHONY: install uninstall test lint clean help
+
+# Default target
+help:
+	@echo "arrctl - Unified CLI for managing *arr services"
+	@echo ""
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  install    Install arrctl (runs install.sh)"
+	@echo "  uninstall  Remove arrctl installation"
+	@echo "  test       Run smoke tests"
+	@echo "  lint       Run shellcheck on all scripts"
+	@echo "  clean      Remove generated files"
+	@echo "  help       Show this help"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  INSTALL_DIR  Installation directory (default: ~/.arrctl)"
+	@echo "  BIN_DIR      Symlink directory (default: /usr/local/bin)"
+
+install:
+	@chmod +x install.sh
+	@./install.sh
+
+uninstall:
+	@echo "Removing arrctl..."
+	@rm -f "$${BIN_DIR:-/usr/local/bin}/arrctl" 2>/dev/null || sudo rm -f "$${BIN_DIR:-/usr/local/bin}/arrctl"
+	@rm -rf "$${INSTALL_DIR:-$$HOME/.arrctl}"
+	@echo "arrctl removed. Config at ~/.config/arrctl was preserved."
+	@echo "To remove config: rm -rf ~/.config/arrctl"
+
+test:
+	@chmod +x test/smoke.sh
+	@./test/smoke.sh
+
+lint:
+	@echo "Running shellcheck..."
+	@shellcheck bin/arrctl lib/*.sh install.sh test/*.sh
+	@echo "All checks passed!"
+
+clean:
+	@echo "Nothing to clean."

--- a/README.md
+++ b/README.md
@@ -10,37 +10,85 @@ Unified CLI for managing *arr services (Sonarr, Radarr, Overseerr, Tautulli).
 - Pipeable JSON output for scripting
 - Minimal dependencies (curl, jq)
 
+## Quick Start
+
+### One-Line Install
+
+```sh
+curl -sSL https://raw.githubusercontent.com/jfriend615/arrctl/main/install.sh | sh
+```
+
+This will:
+- Clone arrctl to `~/.arrctl`
+- Create a symlink in `/usr/local/bin`
+- Generate a config template at `~/.config/arrctl/config.json`
+
+### Custom Installation Paths
+
+```sh
+# Install to a different directory
+INSTALL_DIR=~/tools/arrctl BIN_DIR=~/bin curl -sSL ... | sh
+
+# Or set variables before running
+export INSTALL_DIR="$HOME/tools/arrctl"
+export BIN_DIR="$HOME/bin"
+curl -sSL https://raw.githubusercontent.com/jfriend615/arrctl/main/install.sh | sh
+```
+
+### Manual Installation
+
+```sh
+# Clone the repository
+git clone https://github.com/jfriend615/arrctl.git ~/.arrctl
+
+# Create symlink (may need sudo)
+ln -s ~/.arrctl/bin/arrctl /usr/local/bin/arrctl
+
+# Or add to PATH in your shell profile
+echo 'export PATH="$PATH:$HOME/.arrctl/bin"' >> ~/.bashrc
+```
+
+### Updating
+
+Run the installer again - it will pull the latest changes:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/jfriend615/arrctl/main/install.sh | sh
+```
+
+Or manually:
+
+```sh
+cd ~/.arrctl && git pull
+```
+
+### Uninstalling
+
+```sh
+# Via Makefile (if installed from source)
+make uninstall
+
+# Or manually
+rm /usr/local/bin/arrctl
+rm -rf ~/.arrctl
+rm -rf ~/.config/arrctl  # optional: remove config
+```
+
 ## Requirements
 
 - POSIX shell (sh, dash, bash, etc.)
 - curl
 - jq
+- git (for installation)
 
 Optional:
-- shellcheck (for development/testing)
-
-## Installation
-
-```sh
-# Clone the repository
-git clone https://github.com/jfriend615/arrctl.git
-cd arrctl
-
-# Make the main script executable (if not already)
-chmod +x bin/arrctl
-
-# Option 1: Add to PATH
-export PATH="$PATH:$(pwd)/bin"
-
-# Option 2: Symlink to a directory in your PATH
-ln -s "$(pwd)/bin/arrctl" /usr/local/bin/arrctl
-```
+- shellcheck (for development/linting)
 
 ## Configuration
 
 ### Option 1: Config File (Recommended)
 
-Create `~/.config/arrctl/config.json`:
+Create or edit `~/.config/arrctl/config.json`:
 
 ```json
 {
@@ -63,7 +111,7 @@ Create `~/.config/arrctl/config.json`:
 }
 ```
 
-A template is provided in `config/config.json`.
+The installer creates a template automatically. A sample is also in `config/config.json`.
 
 ### Option 2: Environment Variables
 
@@ -90,7 +138,7 @@ Environment variables take precedence over the config file.
 export ARRCTL_CONFIG="/path/to/config.json"
 
 # Or via command line
-arrctl --config /path/to/config.json sonarr series list
+arrctl --config /path/to/config.json sonarr list
 ```
 
 ## Usage
@@ -102,11 +150,24 @@ arrctl --help
 # Show version
 arrctl --version
 
-# Service commands (coming soon)
-arrctl sonarr <command>
-arrctl radarr <command>
-arrctl overseerr <command>
-arrctl tautulli <command>
+# Sonarr (TV shows)
+arrctl sonarr list              # List all series
+arrctl sonarr search "Breaking Bad"
+arrctl sonarr add --id 12345 --search
+
+# Radarr (Movies)
+arrctl radarr list              # List all movies
+arrctl radarr list --monitored  # Only monitored
+arrctl radarr search "The Matrix"
+arrctl radarr add --id 603 --search
+
+# Overseerr (Requests)
+arrctl overseerr pending        # View pending requests
+arrctl overseerr approve --id 123
+arrctl overseerr deny --id 456 --reason "Duplicate"
+
+# Tautulli (Plex activity)
+arrctl tautulli now             # Who's streaming right now
 ```
 
 ## Project Structure
@@ -116,26 +177,55 @@ arrctl/
 ├── bin/
 │   └── arrctl          # Main entry point
 ├── lib/
-│   └── common.sh       # Shared utilities
+│   ├── common.sh       # Shared utilities
+│   ├── sonarr.sh       # Sonarr commands
+│   ├── radarr.sh       # Radarr commands
+│   ├── overseerr.sh    # Overseerr commands
+│   └── tautulli.sh     # Tautulli commands
 ├── config/
 │   └── config.json     # Config template
+├── test/
+│   └── smoke.sh        # Smoke tests
+├── install.sh          # Installer script
+├── Makefile            # Development tasks
 ├── .gitignore
 └── README.md
 ```
 
 ## Development
 
+### Setup
+
+```sh
+git clone https://github.com/jfriend615/arrctl.git
+cd arrctl
+```
+
 ### Testing
 
 ```sh
-# Check shell syntax with shellcheck
-shellcheck bin/arrctl lib/*.sh
+# Run smoke tests
+make test
 
-# Test with dash (POSIX compliance)
+# Or directly
+./test/smoke.sh
+```
+
+### Linting
+
+```sh
+# Check all scripts with shellcheck
+make lint
+
+# Or directly
+shellcheck bin/arrctl lib/*.sh install.sh
+```
+
+### POSIX Compliance
+
+```sh
+# Test with dash (stricter than bash)
 dash bin/arrctl --help
-
-# Validate config JSON
-jq empty config/config.json
 ```
 
 ### Code Style

--- a/bin/arrctl
+++ b/bin/arrctl
@@ -4,9 +4,21 @@
 
 set -e
 
-# Resolve script directory (works with symlinks)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
+# Resolve script directory (follows symlinks)
+resolve_link() {
+    TARGET="$1"
+    cd "$(dirname "$TARGET")"
+    TARGET=$(basename "$TARGET")
+    # Follow symlinks
+    while [ -L "$TARGET" ]; do
+        TARGET=$(readlink "$TARGET")
+        cd "$(dirname "$TARGET")"
+        TARGET=$(basename "$TARGET")
+    done
+    pwd -P
+}
+SCRIPT_DIR="$(resolve_link "$0")"
+LIB_DIR="${SCRIPT_DIR}/../lib"
 
 # Source common utilities
 # shellcheck source=lib/common.sh

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,223 @@
+#!/bin/sh
+# arrctl installer
+# POSIX compliant - works with sh, dash, bash
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/jfriend615/arrctl/main/install.sh | sh
+#
+# Environment variables:
+#   INSTALL_DIR  - Where to clone arrctl (default: ~/.arrctl)
+#   BIN_DIR      - Where to create symlink (default: /usr/local/bin)
+
+set -e
+
+# Defaults
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.arrctl}"
+BIN_DIR="${BIN_DIR:-/usr/local/bin}"
+REPO_URL="https://github.com/jfriend615/arrctl.git"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/arrctl"
+
+# Colors (if terminal supports them)
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    RED=$(tput setaf 1 2>/dev/null || printf '')
+    GREEN=$(tput setaf 2 2>/dev/null || printf '')
+    YELLOW=$(tput setaf 3 2>/dev/null || printf '')
+    BOLD=$(tput bold 2>/dev/null || printf '')
+    RESET=$(tput sgr0 2>/dev/null || printf '')
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BOLD=""
+    RESET=""
+fi
+
+info() {
+    printf "%s%s%s\n" "$BOLD" "$1" "$RESET"
+}
+
+success() {
+    printf "%s✓%s %s\n" "$GREEN" "$RESET" "$1"
+}
+
+warn() {
+    printf "%s!%s %s\n" "$YELLOW" "$RESET" "$1"
+}
+
+error() {
+    printf "%s✗%s %s\n" "$RED" "$RESET" "$1" >&2
+}
+
+die() {
+    error "$1"
+    exit 1
+}
+
+# Check for required dependencies
+check_dependencies() {
+    info "Checking dependencies..."
+    
+    missing=""
+    
+    if ! command -v curl >/dev/null 2>&1; then
+        missing="$missing curl"
+    fi
+    
+    if ! command -v jq >/dev/null 2>&1; then
+        missing="$missing jq"
+    fi
+    
+    if ! command -v git >/dev/null 2>&1; then
+        missing="$missing git"
+    fi
+    
+    if [ -n "$missing" ]; then
+        die "Missing required dependencies:$missing"
+    fi
+    
+    success "All dependencies found (curl, jq, git)"
+}
+
+# Clone or update the repository
+install_repo() {
+    if [ -d "$INSTALL_DIR" ]; then
+        if [ -d "$INSTALL_DIR/.git" ]; then
+            info "Updating existing installation at $INSTALL_DIR..."
+            cd "$INSTALL_DIR"
+            git pull --ff-only origin main 2>/dev/null || git pull origin main
+            success "Updated to latest version"
+        else
+            die "$INSTALL_DIR exists but is not a git repository. Remove it first or set INSTALL_DIR."
+        fi
+    else
+        info "Cloning arrctl to $INSTALL_DIR..."
+        git clone "$REPO_URL" "$INSTALL_DIR"
+        success "Cloned arrctl"
+    fi
+    
+    # Ensure executable
+    chmod +x "$INSTALL_DIR/bin/arrctl"
+}
+
+# Create symlink in BIN_DIR
+create_symlink() {
+    target="$INSTALL_DIR/bin/arrctl"
+    link="$BIN_DIR/arrctl"
+    
+    info "Creating symlink at $link..."
+    
+    # Check if link already exists and points to correct target
+    if [ -L "$link" ]; then
+        existing_target=$(readlink "$link" 2>/dev/null || true)
+        if [ "$existing_target" = "$target" ]; then
+            success "Symlink already exists and is correct"
+            return 0
+        else
+            warn "Symlink exists but points to $existing_target"
+            # Try to update it
+        fi
+    elif [ -e "$link" ]; then
+        die "$link exists and is not a symlink. Remove it manually first."
+    fi
+    
+    # Create BIN_DIR if it doesn't exist
+    if [ ! -d "$BIN_DIR" ]; then
+        if mkdir -p "$BIN_DIR" 2>/dev/null; then
+            : # success
+        elif command -v sudo >/dev/null 2>&1; then
+            sudo mkdir -p "$BIN_DIR"
+        else
+            die "Cannot create $BIN_DIR. Try running with sudo or set BIN_DIR to a writable location."
+        fi
+    fi
+    
+    # Try to create symlink, with sudo fallback
+    if ln -sf "$target" "$link" 2>/dev/null; then
+        success "Created symlink"
+    elif command -v sudo >/dev/null 2>&1; then
+        info "Need elevated permissions for $BIN_DIR..."
+        if sudo ln -sf "$target" "$link"; then
+            success "Created symlink (with sudo)"
+        else
+            die "Failed to create symlink even with sudo"
+        fi
+    else
+        warn "Could not create symlink in $BIN_DIR"
+        echo ""
+        echo "Add this to your shell profile instead:"
+        echo "  export PATH=\"\$PATH:$INSTALL_DIR/bin\""
+        return 1
+    fi
+}
+
+# Create config template
+create_config() {
+    config_file="$CONFIG_DIR/config.json"
+    
+    if [ -f "$config_file" ]; then
+        success "Config file already exists at $config_file"
+        return 0
+    fi
+    
+    info "Creating config template at $config_file..."
+    
+    mkdir -p "$CONFIG_DIR"
+    
+    cat > "$config_file" <<'EOF'
+{
+  "sonarr": {
+    "url": "http://localhost:8989",
+    "api_key": "your-sonarr-api-key-here"
+  },
+  "radarr": {
+    "url": "http://localhost:7878",
+    "api_key": "your-radarr-api-key-here"
+  },
+  "overseerr": {
+    "url": "http://localhost:5055",
+    "api_key": "your-overseerr-api-key-here"
+  },
+  "tautulli": {
+    "url": "http://localhost:8181",
+    "api_key": "your-tautulli-api-key-here"
+  }
+}
+EOF
+    
+    success "Created config template"
+}
+
+# Print final message
+print_success() {
+    echo ""
+    printf "%s%s========================================%s\n" "$GREEN" "$BOLD" "$RESET"
+    printf "%s%s arrctl installed successfully! %s\n" "$GREEN" "$BOLD" "$RESET"
+    printf "%s%s========================================%s\n" "$GREEN" "$BOLD" "$RESET"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Edit your config file with API keys:"
+    echo "     ${CONFIG_DIR}/config.json"
+    echo ""
+    echo "  2. Verify installation:"
+    echo "     arrctl --version"
+    echo ""
+    echo "  3. Get started:"
+    echo "     arrctl --help"
+    echo ""
+    echo "Documentation: https://github.com/jfriend615/arrctl"
+}
+
+# Main
+main() {
+    echo ""
+    printf "%s%sarrctl installer%s\n" "$BOLD" "$GREEN" "$RESET"
+    echo ""
+    
+    check_dependencies
+    install_repo
+    create_symlink
+    create_config
+    print_success
+}
+
+main "$@"

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -78,6 +78,7 @@ if command -v shellcheck >/dev/null 2>&1; then
     test_case "shellcheck: lib/radarr.sh" shellcheck -s sh "${REPO_DIR}/lib/radarr.sh"
     test_case "shellcheck: lib/tautulli.sh" shellcheck -s sh "${REPO_DIR}/lib/tautulli.sh"
     test_case "shellcheck: lib/overseerr.sh" shellcheck -s sh "${REPO_DIR}/lib/overseerr.sh"
+    test_case "shellcheck: install.sh" shellcheck -s sh "${REPO_DIR}/install.sh"
 else
     skip "shellcheck not installed"
 fi
@@ -89,6 +90,7 @@ if command -v dash >/dev/null 2>&1; then
     test_case "dash -n: lib/radarr.sh" dash -n "${REPO_DIR}/lib/radarr.sh"
     test_case "dash -n: lib/tautulli.sh" dash -n "${REPO_DIR}/lib/tautulli.sh"
     test_case "dash -n: lib/overseerr.sh" dash -n "${REPO_DIR}/lib/overseerr.sh"
+    test_case "dash -n: install.sh" dash -n "${REPO_DIR}/install.sh"
 else
     skip "dash not installed"
 fi


### PR DESCRIPTION
Adds one-line installation support for arrctl.

## Changes

- **install.sh** — POSIX-compliant installer script
  - Checks dependencies (curl, jq, git)
  - Clones repo to ~/.arrctl (or custom INSTALL_DIR)
  - Creates symlink in /usr/local/bin (or custom BIN_DIR)
  - Creates config template at ~/.config/arrctl/config.json
  - Idempotent: running twice updates existing installation
  - Handles permission issues gracefully (sudo fallback)

- **README.md** — Updated with installation docs
  - Quick install: curl | sh one-liner
  - Custom paths via environment variables
  - Manual install instructions
  - Update and uninstall instructions

- **Makefile** — Development convenience targets
  - make install — run installer
  - make test — run smoke tests
  - make lint — run shellcheck
  - make uninstall — remove installation

- **bin/arrctl** — Fixed symlink resolution
  - Script now properly follows symlinks
  - Allows arrctl to work when symlinked from /usr/local/bin

- **test/smoke.sh** — Added install.sh to test suite

## Installation

    curl -sSL https://raw.githubusercontent.com/jfriend615/arrctl/main/install.sh | sh

## Testing

All 45 smoke tests pass:
- POSIX compliance (shellcheck + dash)
- Help commands for all services
- Error handling
- Install script syntax