### PR TITLE
feat: add calendar command for upcoming releases

### DIFF
--- a/bin/arrctl
+++ b/bin/arrctl
@@ -64,6 +64,171 @@ arrctl_update() {
     fi
 }
 
+# Show help for calendar command
+calendar_help() {
+    cat <<EOF
+arrctl calendar - Unified calendar view for upcoming releases
+
+Usage: arrctl calendar [options]
+
+Options:
+    --days N          Show next N days (default: 7)
+    --week            Show this week (Monday to Sunday)
+    --sonarr          Show only TV episodes (Sonarr)
+    --radarr          Show only movies (Radarr)
+    --format FORMAT   Output format: json|table|auto (default: auto)
+    -h, --help        Show this help message
+
+Examples:
+    arrctl calendar                    # Next 7 days, both services
+    arrctl calendar --week             # This week (Mon-Sun)
+    arrctl calendar --sonarr           # TV only
+    arrctl calendar --radarr           # Movies only
+    arrctl calendar --days 14          # Next 2 weeks
+
+EOF
+}
+
+# Calendar command - show upcoming releases from Sonarr and Radarr
+arrctl_calendar() {
+    _days=7
+    _week=0
+    _sonarr=1
+    _radarr=1
+    _format="auto"
+    
+    # Parse options
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --days)
+                if [ -z "${2:-}" ]; then
+                    die "--days requires a number"
+                fi
+                _days="$2"
+                shift 2
+                ;;
+            --days=*)
+                _days="${1#--days=}"
+                shift
+                ;;
+            --week)
+                _week=1
+                shift
+                ;;
+            --sonarr)
+                _sonarr=1
+                _radarr=0
+                shift
+                ;;
+            --radarr)
+                _sonarr=0
+                _radarr=1
+                shift
+                ;;
+            --format)
+                if [ -z "${2:-}" ]; then
+                    die "--format requires a value (json|table|auto)"
+                fi
+                _format="$2"
+                shift 2
+                ;;
+            --format=*)
+                _format="${1#--format=}"
+                shift
+                ;;
+            -h|--help|help)
+                calendar_help
+                return 0
+                ;;
+            *)
+                die "Unknown option: $1. Use 'arrctl calendar --help' for usage."
+                ;;
+        esac
+    done
+    
+    # Calculate start and end dates
+    if [ "$_week" -eq 1 ]; then
+        # This week: Monday to Sunday
+        # Get day of week (1=Monday, 7=Sunday)
+        _dow=$(date +%u)
+        _days_to_monday=$((_dow - 1))
+        _days_to_sunday=$((7 - _dow))
+        
+        # BSD date (macOS) vs GNU date (Linux)
+        if date -v-1d +%Y-%m-%d >/dev/null 2>&1; then
+            # BSD date
+            _start=$(date -v-${_days_to_monday}d +%Y-%m-%d)
+            _end=$(date -v+${_days_to_sunday}d +%Y-%m-%d)
+        else
+            # GNU date
+            _start=$(date -d "-${_days_to_monday} days" +%Y-%m-%d)
+            _end=$(date -d "+${_days_to_sunday} days" +%Y-%m-%d)
+        fi
+    else
+        # Default: next N days
+        _start=$(date +%Y-%m-%d)
+        
+        # BSD date (macOS) vs GNU date (Linux)
+        if date -v+1d +%Y-%m-%d >/dev/null 2>&1; then
+            # BSD date
+            _end=$(date -v+"${_days}"d +%Y-%m-%d)
+        else
+            # GNU date
+            _end=$(date -d "+${_days} days" +%Y-%m-%d)
+        fi
+    fi
+    
+    # Collect calendar data
+    _sonarr_data="[]"
+    _radarr_data="[]"
+    
+    if [ "$_sonarr" -eq 1 ]; then
+        # Load sonarr config and fetch calendar
+        if load_config "sonarr" 2>/dev/null; then
+            # shellcheck disable=SC1090,SC1091
+            . "${LIB_DIR}/sonarr.sh"
+            _sonarr_data="$(sonarr_calendar_raw "$_start" "$_end" 2>/dev/null || echo "[]")"
+        fi
+    fi
+    
+    if [ "$_radarr" -eq 1 ]; then
+        # Load radarr config and fetch calendar
+        if load_config "radarr" 2>/dev/null; then
+            # shellcheck disable=SC1090,SC1091
+            . "${LIB_DIR}/radarr.sh"
+            _radarr_data="$(radarr_calendar_raw "$_start" "$_end" 2>/dev/null || echo "[]")"
+        fi
+    fi
+    
+    # Merge and sort results
+    _merged=$(printf '%s\n%s' "$_sonarr_data" "$_radarr_data" | jq -s 'add | sort_by(.date)')
+    
+    # Check if empty
+    _count=$(printf '%s' "$_merged" | jq 'length')
+    if [ "$_count" -eq 0 ]; then
+        info "No releases in this period ($_start to $_end)"
+        return 0
+    fi
+    
+    # Determine output format
+    _use_table=0
+    case "$_format" in
+        table) _use_table=1 ;;
+        auto) [ -t 1 ] && _use_table=1 ;;
+    esac
+    
+    if [ "$_use_table" -eq 1 ]; then
+        # Print table header
+        printf '%s\t%s\t%s\t%s\n' "Date" "Title" "Episode" "Service"
+        printf '%s\t%s\t%s\t%s\n' "----------" "--------------------" "---------------" "-------"
+        # Print rows
+        printf '%s' "$_merged" | jq -r '.[] | [.date, .title, .episode, .service] | @tsv'
+    else
+        # JSON output
+        printf '%s\n' "$_merged" | jq '.'
+    fi
+}
+
 show_help() {
     cat <<EOF
 arrctl - Unified CLI for managing *arr services
@@ -75,6 +240,7 @@ Commands:
     radarr      Manage Radarr (Movies)
     overseerr   Manage Overseerr (Requests)
     tautulli    View Plex activity (who is streaming)
+    calendar    Show upcoming releases (TV + Movies)
     update      Update arrctl to the latest version
 
 Options:
@@ -103,6 +269,8 @@ Examples:
     arrctl radarr add --id 603 --search
     arrctl overseerr pending
     arrctl tautulli now
+    arrctl calendar
+    arrctl calendar --days 14 --sonarr
 
 EOF
 }
@@ -127,6 +295,10 @@ main() {
         update)
             shift
             arrctl_update "$@"
+            ;;
+        calendar)
+            shift
+            arrctl_calendar "$@"
             ;;
         sonarr|radarr|overseerr|tautulli)
             SERVICE="$1"

--- a/lib/radarr.sh
+++ b/lib/radarr.sh
@@ -13,6 +13,7 @@ Commands:
     list              List all movies in library
     search <term>     Search for movies by name
     add               Add a movie to library
+    calendar          Show upcoming movie releases
 
 List Options:
     --monitored       Show only monitored movies
@@ -32,12 +33,19 @@ Add Options:
     --monitored       Monitor the movie (default: true)
     --no-monitored    Don't monitor the movie
 
+Calendar Options:
+    --days N          Show next N days (default: 7)
+    --start DATE      Start date (YYYY-MM-DD)
+    --end DATE        End date (YYYY-MM-DD)
+    --format FORMAT   Output format: json|table|auto (default: auto)
+
 Examples:
     arrctl radarr list
     arrctl radarr list --monitored --format table
     arrctl radarr search "The Matrix"
     arrctl radarr search "Dune" --limit 5
     arrctl radarr add --id 603 --quality "HD-1080p" --search
+    arrctl radarr calendar --days 30
 
 EOF
 }
@@ -79,6 +87,10 @@ radarr_main() {
         add)
             shift
             radarr_add "$@"
+            ;;
+        calendar)
+            shift
+            radarr_calendar "$@"
             ;;
         *)
             die "Unknown radarr command: $1. Use 'arrctl radarr --help' for usage."
@@ -405,4 +417,98 @@ _radarr_resolve_root_folder() {
     fi
     
     printf '%s' "$_path"
+}
+
+# Get calendar entries (upcoming movie releases)
+# Usage: radarr_calendar [--days N] [--start DATE] [--end DATE]
+radarr_calendar() {
+    _days=7
+    _start=""
+    _end=""
+    
+    # Parse calendar-specific options
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --days)
+                if [ -z "${2:-}" ]; then
+                    die "--days requires a number"
+                fi
+                _days="$2"
+                shift 2
+                ;;
+            --days=*)
+                _days="${1#--days=}"
+                shift
+                ;;
+            --start)
+                if [ -z "${2:-}" ]; then
+                    die "--start requires a date (YYYY-MM-DD)"
+                fi
+                _start="$2"
+                shift 2
+                ;;
+            --start=*)
+                _start="${1#--start=}"
+                shift
+                ;;
+            --end)
+                if [ -z "${2:-}" ]; then
+                    die "--end requires a date (YYYY-MM-DD)"
+                fi
+                _end="$2"
+                shift 2
+                ;;
+            --end=*)
+                _end="${1#--end=}"
+                shift
+                ;;
+            -h|--help)
+                radarr_help
+                return 0
+                ;;
+            *)
+                die "Unknown option: $1"
+                ;;
+        esac
+    done
+    
+    # Calculate dates if not provided
+    if [ -z "$_start" ]; then
+        _start=$(date +%Y-%m-%d)
+    fi
+    if [ -z "$_end" ]; then
+        # Try BSD date first, fall back to GNU date
+        _end=$(date -v+"${_days}"d +%Y-%m-%d 2>/dev/null || date -d "+${_days} days" +%Y-%m-%d)
+    fi
+    
+    # Fetch calendar data
+    _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
+    
+    # Format output - transform to unified format with date, title, episode (empty for movies), service
+    # Use digitalRelease if available, otherwise inCinemas, otherwise physicalRelease
+    printf '%s' "$_response" | jq '[.[] | {
+        date: ((.digitalRelease // .inCinemas // .physicalRelease // "") | split("T")[0]),
+        title: .title,
+        episode: "",
+        service: "Radarr"
+    }] | map(select(.date != ""))'
+}
+
+# Get calendar entries in raw JSON format for merging
+# Usage: radarr_calendar_raw start_date end_date
+# Outputs normalized JSON array for calendar merging
+radarr_calendar_raw() {
+    _start="$1"
+    _end="$2"
+    
+    # Fetch calendar data
+    _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
+    
+    # Transform to unified format
+    printf '%s' "$_response" | jq '[.[] | {
+        date: ((.digitalRelease // .inCinemas // .physicalRelease // "") | split("T")[0]),
+        title: .title,
+        episode: "",
+        service: "Radarr"
+    }] | map(select(.date != ""))'
 }

--- a/lib/sonarr.sh
+++ b/lib/sonarr.sh
@@ -13,6 +13,7 @@ Commands:
     list              List all series in library
     search <term>     Search for series by name
     add               Add a series to library
+    calendar          Show upcoming episodes
 
 List Options:
     --monitored       Show only monitored series
@@ -32,12 +33,19 @@ Add Options:
     --monitored       Monitor the series (default: true)
     --no-monitored    Don't monitor the series
 
+Calendar Options:
+    --days N          Show next N days (default: 7)
+    --start DATE      Start date (YYYY-MM-DD)
+    --end DATE        End date (YYYY-MM-DD)
+    --format FORMAT   Output format: json|table|auto (default: auto)
+
 Examples:
     arrctl sonarr list
     arrctl sonarr list --monitored --format table
     arrctl sonarr search "Breaking Bad"
     arrctl sonarr search "The Office" --limit 5
     arrctl sonarr add --id 81189 --quality "HD-1080p" --search
+    arrctl sonarr calendar --days 14
 
 EOF
 }
@@ -79,6 +87,10 @@ sonarr_main() {
         add)
             shift
             sonarr_add "$@"
+            ;;
+        calendar)
+            shift
+            sonarr_calendar "$@"
             ;;
         *)
             die "Unknown sonarr command: $1. Use 'arrctl sonarr --help' for usage."
@@ -407,4 +419,97 @@ _sonarr_resolve_root_folder() {
     fi
     
     printf '%s' "$_path"
+}
+
+# Get calendar entries (upcoming episodes)
+# Usage: sonarr_calendar [--days N] [--start DATE] [--end DATE]
+sonarr_calendar() {
+    _days=7
+    _start=""
+    _end=""
+    
+    # Parse calendar-specific options
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --days)
+                if [ -z "${2:-}" ]; then
+                    die "--days requires a number"
+                fi
+                _days="$2"
+                shift 2
+                ;;
+            --days=*)
+                _days="${1#--days=}"
+                shift
+                ;;
+            --start)
+                if [ -z "${2:-}" ]; then
+                    die "--start requires a date (YYYY-MM-DD)"
+                fi
+                _start="$2"
+                shift 2
+                ;;
+            --start=*)
+                _start="${1#--start=}"
+                shift
+                ;;
+            --end)
+                if [ -z "${2:-}" ]; then
+                    die "--end requires a date (YYYY-MM-DD)"
+                fi
+                _end="$2"
+                shift 2
+                ;;
+            --end=*)
+                _end="${1#--end=}"
+                shift
+                ;;
+            -h|--help)
+                sonarr_help
+                return 0
+                ;;
+            *)
+                die "Unknown option: $1"
+                ;;
+        esac
+    done
+    
+    # Calculate dates if not provided
+    if [ -z "$_start" ]; then
+        _start=$(date +%Y-%m-%d)
+    fi
+    if [ -z "$_end" ]; then
+        # Try BSD date first, fall back to GNU date
+        _end=$(date -v+"${_days}"d +%Y-%m-%d 2>/dev/null || date -d "+${_days} days" +%Y-%m-%d)
+    fi
+    
+    # Fetch calendar data
+    _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
+    
+    # Format output - transform to unified format with date, title, episode, service
+    printf '%s' "$_response" | jq '[.[] | {
+        date: (.airDateUtc | split("T")[0]),
+        title: .series.title,
+        episode: ("S" + (if .seasonNumber < 10 then "0" else "" end) + (.seasonNumber | tostring) + "E" + (if .episodeNumber < 10 then "0" else "" end) + (.episodeNumber | tostring) + " - " + .title),
+        service: "Sonarr"
+    }]'
+}
+
+# Get calendar entries in raw JSON format for merging
+# Usage: sonarr_calendar_raw start_date end_date
+# Outputs normalized JSON array for calendar merging
+sonarr_calendar_raw() {
+    _start="$1"
+    _end="$2"
+    
+    # Fetch calendar data
+    _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
+    
+    # Transform to unified format
+    printf '%s' "$_response" | jq '[.[] | {
+        date: (.airDateUtc | split("T")[0]),
+        title: .series.title,
+        episode: ("S" + (if .seasonNumber < 10 then "0" else "" end) + (.seasonNumber | tostring) + "E" + (if .episodeNumber < 10 then "0" else "" end) + (.episodeNumber | tostring) + " - " + .title),
+        service: "Sonarr"
+    }]'
 }

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -108,6 +108,8 @@ test_case "arrctl tautulli --help works" "$ARRCTL" tautulli --help
 test_case "arrctl tautulli help works" "$ARRCTL" tautulli help
 test_case "arrctl overseerr --help works" "$ARRCTL" overseerr --help
 test_case "arrctl overseerr help works" "$ARRCTL" overseerr help
+test_case "arrctl calendar --help works" "$ARRCTL" calendar --help
+test_case "arrctl calendar help works" "$ARRCTL" calendar help
 
 # Invalid command handling
 printf '\n%s\n' "--- Error Handling ---"
@@ -149,6 +151,12 @@ else
     fail "Main help mentions update"
 fi
 
+if "$ARRCTL" --help 2>&1 | grep -q "calendar"; then
+    pass "Main help mentions calendar"
+else
+    fail "Main help mentions calendar"
+fi
+
 if "$ARRCTL" sonarr --help 2>&1 | grep -q "list"; then
     pass "Sonarr help mentions list"
 else
@@ -167,6 +175,12 @@ else
     fail "Sonarr help mentions add"
 fi
 
+if "$ARRCTL" sonarr --help 2>&1 | grep -q "calendar"; then
+    pass "Sonarr help mentions calendar"
+else
+    fail "Sonarr help mentions calendar"
+fi
+
 if "$ARRCTL" radarr --help 2>&1 | grep -q "list"; then
     pass "Radarr help mentions list"
 else
@@ -183,6 +197,24 @@ if "$ARRCTL" radarr --help 2>&1 | grep -q "add"; then
     pass "Radarr help mentions add"
 else
     fail "Radarr help mentions add"
+fi
+
+if "$ARRCTL" radarr --help 2>&1 | grep -q "calendar"; then
+    pass "Radarr help mentions calendar"
+else
+    fail "Radarr help mentions calendar"
+fi
+
+if "$ARRCTL" calendar --help 2>&1 | grep -q "days"; then
+    pass "Calendar help mentions days"
+else
+    fail "Calendar help mentions days"
+fi
+
+if "$ARRCTL" calendar --help 2>&1 | grep -q "week"; then
+    pass "Calendar help mentions week"
+else
+    fail "Calendar help mentions week"
 fi
 
 if "$ARRCTL" tautulli --help 2>&1 | grep -q "now"; then


### PR DESCRIPTION
## Summary

Add a unified calendar view showing upcoming releases from both Sonarr (TV episodes) and Radarr (movies).

## Changes

### New Commands

- `arrctl calendar` - Unified view of upcoming releases
- `arrctl sonarr calendar` - TV episodes only
- `arrctl radarr calendar` - Movies only

### Features

- **Date range options:**
  - `--days N` - Show next N days (default: 7)
  - `--week` - Show this week (Monday to Sunday)
  - `--start DATE` / `--end DATE` - Custom date range

- **Service filters:**
  - `--sonarr` - Show only TV episodes
  - `--radarr` - Show only movies

- **Output formats:**
  - Table format for terminals
  - JSON output for pipes/scripts

### Example Output

```
arrctl calendar --days 7

Date        Title                Episode          Service
----------  --------------------  ---------------  -------
2024-01-15  Breaking Bad         S01E01 - Pilot   Sonarr
2024-01-15  Dune: Part Two                        Radarr
2024-01-17  Better Call Saul     S06E03 - Rock... Sonarr
```

## Files Changed

- `bin/arrctl` - Add calendar dispatcher and arrctl_calendar()
- `lib/sonarr.sh` - Add sonarr_calendar() and sonarr_calendar_raw()
- `lib/radarr.sh` - Add radarr_calendar() and radarr_calendar_raw()
- `test/smoke.sh` - Add calendar command tests

## Testing

- All smoke tests pass (54/54)
- shellcheck clean
- dash -n syntax validation passes
- POSIX compliant