### PR TITLE
fix(calendar): show actual series titles via in-memory lookup

### DIFF
--- a/lib/sonarr.sh
+++ b/lib/sonarr.sh
@@ -483,14 +483,17 @@ sonarr_calendar() {
         _end=$(date -v+"${_days}"d +%Y-%m-%d 2>/dev/null || date -d "+${_days} days" +%Y-%m-%d)
     fi
     
+    # Fetch all series for title lookup (in-memory cache)
+    _series_list="$(api_request GET "/api/v3/series")"
+    _series_lookup="$(printf '%s' "$_series_list" | jq 'map({(.id | tostring): .title}) | add // {}')"
+    
     # Fetch calendar data
     _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
     
     # Format output - transform to unified format with date, title, episode, service
-    # Note: Sonarr calendar API returns seriesId but not series title
-    printf '%s' "$_response" | jq '[.[] | {
+    printf '%s' "$_response" | jq --argjson lookup "$_series_lookup" '[.[] | {
         date: (.airDateUtc | split("T")[0]),
-        title: ("Series ID: " + (.seriesId | tostring)),
+        title: ($lookup[(.seriesId | tostring)] // "Unknown Series"),
         episode: ("S" + (if .seasonNumber < 10 then "0" else "" end) + (.seasonNumber | tostring) + "E" + (if .episodeNumber < 10 then "0" else "" end) + (.episodeNumber | tostring) + " - " + .title),
         service: "Sonarr"
     }]'
@@ -503,14 +506,17 @@ sonarr_calendar_raw() {
     _start="$1"
     _end="$2"
     
+    # Fetch all series for title lookup (in-memory cache)
+    _series_list="$(api_request GET "/api/v3/series")"
+    _series_lookup="$(printf '%s' "$_series_list" | jq 'map({(.id | tostring): .title}) | add // {}')"
+    
     # Fetch calendar data
     _response="$(api_request GET "/api/v3/calendar?start=${_start}&end=${_end}")"
     
-    # Transform to unified format
-    # Note: Sonarr calendar API returns seriesId but not series title
-    printf '%s' "$_response" | jq '[.[] | {
+    # Transform to unified format with series title lookup
+    printf '%s' "$_response" | jq --argjson lookup "$_series_lookup" '[.[] | {
         date: (.airDateUtc | split("T")[0]),
-        title: ("Series ID: " + (.seriesId | tostring)),
+        title: ($lookup[(.seriesId | tostring)] // "Unknown Series"),
         episode: ("S" + (if .seasonNumber < 10 then "0" else "" end) + (.seasonNumber | tostring) + "E" + (if .episodeNumber < 10 then "0" else "" end) + (.episodeNumber | tostring) + " - " + .title),
         service: "Sonarr"
     }]'


### PR DESCRIPTION
Sonarr calendar API returns seriesId but not series title. This fix:

- Fetches all series from /api/v3/series to build an in-memory lookup table
- Maps seriesId to actual series title using jq --argjson lookup
- Falls back to 'Unknown Series' if seriesId is not found in lookup
- Applied to both sonarr_calendar() and sonarr_calendar_raw() functions

Radarr calendar API already includes movie titles, so no changes needed there.

Before: Shows 'Series ID: 639'
After: Shows actual series name like 'Breaking Bad'