### PR TITLE
feat: use column command for better table formatting

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -258,11 +258,18 @@ format_table() {
     esac
     
     if [ "$_use_table" -eq 1 ]; then
-        # Print headers
-        printf '%s\n' "$_headers" | tr '|' '\t'
-        printf '%s\n' "$_headers" | sed 's/[^|]/-/g' | tr '|' '\t'
-        # Print rows
-        jq -r "$_jq_expr | @tsv"
+        # Check if column command is available
+        if command -v column >/dev/null 2>&1; then
+            # Build table with headers and pipe to column for alignment
+            {
+                printf '%s\n' "$_headers"
+                jq -r "$_jq_expr | join(\"|\")"
+            } | column -t -s '|'
+        else
+            # Fallback to simple tab format if column not available
+            printf '%s\n' "$_headers" | tr '|' '\t'
+            jq -r "$_jq_expr | @tsv"
+        fi
     else
         # Pass through as JSON
         jq '.'


### PR DESCRIPTION
Improve table output alignment by using the standard `column` command instead of manual tab formatting.

Changes:
- Use `column -t -s '|'` for automatic column alignment
- Headers and data use pipe character as separator
- Fallback to simple tab format if column command unavailable (rare edge case)
- Remove manual header underline (column handles spacing)

The column command is available on virtually all Unix systems (macOS, Linux) and produces cleaner, properly aligned output regardless of content width.

Testing:
- All smoke tests pass (54/54)
- shellcheck clean