### PR TITLE
fix(calendar): use format_table for aligned output

### DIFF
--- a/bin/arrctl
+++ b/bin/arrctl
@@ -218,11 +218,8 @@ arrctl_calendar() {
     esac
     
     if [ "$_use_table" -eq 1 ]; then
-        # Print table header
-        printf '%s\t%s\t%s\t%s\n' "Date" "Title" "Episode" "Service"
-        printf '%s\t%s\t%s\t%s\n' "----------" "--------------------" "---------------" "-------"
-        # Print rows
-        printf '%s' "$_merged" | jq -r '.[] | [.date, .title, .episode, .service] | @tsv'
+        # Use format_table for aligned output
+        printf '%s' "$_merged" | format_table "Date|Title|Episode|Service" '.[] | [.date, .title, .episode, .service]'
     else
         # JSON output
         printf '%s\n' "$_merged" | jq '.'


### PR DESCRIPTION
The arrctl_calendar() function was using manual tab-based formatting:

  printf '%s\t%s\t%s\t%s\n' "Date" "Title" "Episode" "Service"
  printf '%s' "$merged" | jq -r '.[] | @tsv'

This bypassed the format_table() function which uses column -t for proper alignment.

Changes:
- Removed manual header printing with tabs
- Removed manual row printing with @tsv
- Now uses format_table() with pipe-separated headers

Testing:
- shellcheck clean
- All 54 smoke tests pass
- arrctl calendar output now properly aligned via column -t