### PR TITLE
fix(sonarr): clean up info table layout

### DIFF
--- a/lib/radarr.sh
+++ b/lib/radarr.sh
@@ -408,8 +408,6 @@ radarr_info() {
 
     _profiles="$(api_request GET "/api/v3/qualityprofile")"
     _profile_lookup="$(printf '%s' "$_profiles" | jq 'map({(.id|tostring): .name}) | add // {}')"
-    _tags="$(api_request GET "/api/v3/tag")"
-    _tag_lookup="$(printf '%s' "$_tags" | jq 'map({(.id|tostring): .label}) | add // {}')"
 
     _out='[]'
     _idx=0
@@ -424,7 +422,6 @@ radarr_info() {
 
         _enriched="$(printf '%s' "$_one" | jq \
             --argjson profiles "$_profile_lookup" \
-            --argjson tags "$_tag_lookup" \
             --argjson movieFile "$_movie_file" \
             '{
                 id,
@@ -433,10 +430,11 @@ radarr_info() {
                 status,
                 monitored,
                 qualityProfileName: ($profiles[(.qualityProfileId|tostring)] // "Unknown"),
-                rootFolder: (.rootFolderPath // ""),
                 overview: (.overview // ""),
-                tags: ((.tags // []) | map($tags[(tostring)] // ("Tag-" + (tostring)))),
-                movieFile: ($movieFile // .movieFile // null)
+                movieSizeGb: (
+                    (($movieFile // .movieFile // null) | .size // null)
+                    | if . == null then null else ((. / (1024*1024*1024) * 10 | round) / 10) end
+                )
             }')"
 
         _out="$(printf '%s\n%s' "$_out" "$_enriched" | jq -s '.[0] + [.[1]]')"
@@ -444,7 +442,7 @@ radarr_info() {
     done
 
     printf '%s' "$_out" | format_table \
-        "ID|Title|Year|Status|Monitored|Quality Profile|Root Folder|Tags|Movie File|Overview" \
+        "ID|Title|Year|Status|Monitored|Quality Profile|Size (GB)|Overview" \
         '.[] | [
             .id,
             .title,
@@ -452,9 +450,7 @@ radarr_info() {
             .status,
             (if .monitored then "Yes" else "No" end),
             .qualityProfileName,
-            .rootFolder,
-            ((.tags // []) | join(", ")),
-            (if (.movieFile // null) == null then "Not Downloaded" else ((.movieFile.relativePath // .movieFile.path // "") + " | " + (((.movieFile.size // 0) / (1024*1024*1024) | floor | tostring) + " GB") + " | " + (.movieFile.quality.quality.name // "Unknown")) end),
+            (if .movieSizeGb == null then "Not Downloaded" else ((.movieSizeGb | tostring) + " GB") end),
             .overview
         ]'
 }

--- a/lib/sonarr.sh
+++ b/lib/sonarr.sh
@@ -410,8 +410,6 @@ sonarr_info() {
 
     _profiles="$(api_request GET "/api/v3/qualityprofile")"
     _profile_lookup="$(printf '%s' "$_profiles" | jq 'map({(.id|tostring): .name}) | add // {}')"
-    _tags="$(api_request GET "/api/v3/tag")"
-    _tag_lookup="$(printf '%s' "$_tags" | jq 'map({(.id|tostring): .label}) | add // {}')"
 
     _out='[]'
     _idx=0
@@ -421,13 +419,10 @@ sonarr_info() {
 
         _episodes="$(api_request GET "/api/v3/episode?seriesId=${_series_id}")"
         _episode_count="$(printf '%s' "$_episodes" | jq 'length')"
-        _episode_files="$(api_request GET "/api/v3/episodefile?seriesId=${_series_id}")"
 
         _enriched="$(printf '%s' "$_one" | jq \
             --argjson profiles "$_profile_lookup" \
-            --argjson tags "$_tag_lookup" \
             --argjson episodeCount "$_episode_count" \
-            --argjson episodeFiles "$_episode_files" \
             '{
                 id,
                 title,
@@ -435,12 +430,9 @@ sonarr_info() {
                 status,
                 monitored,
                 qualityProfileName: ($profiles[(.qualityProfileId|tostring)] // "Unknown"),
-                rootFolder: (.rootFolderPath // ""),
                 overview: (.overview // ""),
-                tags: ((.tags // []) | map($tags[(tostring)] // ("Tag-" + (tostring)))),
                 seasonsCount: ((.seasons // []) | length),
-                episodesCount: $episodeCount,
-                episodeFiles: ($episodeFiles | map(.relativePath // .path // ("ID:" + (.id|tostring))))
+                episodesCount: $episodeCount
             }')"
 
         _out="$(printf '%s\n%s' "$_out" "$_enriched" | jq -s '.[0] + [.[1]]')"
@@ -448,7 +440,7 @@ sonarr_info() {
     done
 
     printf '%s' "$_out" | format_table \
-        "ID|Title|Year|Status|Monitored|Quality Profile|Root Folder|Seasons|Episodes|Tags|Episode Files|Overview" \
+        "ID|Title|Year|Status|Monitored|Quality Profile|Seasons|Episodes|Overview" \
         '.[] | [
             .id,
             .title,
@@ -456,11 +448,8 @@ sonarr_info() {
             .status,
             (if .monitored then "Yes" else "No" end),
             .qualityProfileName,
-            .rootFolder,
             .seasonsCount,
             .episodesCount,
-            ((.tags // []) | join(", ")),
-            ((.episodeFiles // []) | join(", ")),
             .overview
         ]'
 }


### PR DESCRIPTION
## Summary
- remove low-value verbose fields from `arrctl sonarr info` table output
- drop `Root Folder`, `Tags`, and `Episode Files` from headers and row mapping
- keep concise fields for quick scanning: ID, Title, Year, Status, Monitored, Quality Profile, Seasons, Episodes, Overview

## Why
`Episode Files` includes long file paths that break table layout and readability; `Tags` and `Root Folder` are also low-value in this view.